### PR TITLE
Faster requests and multiple arguments

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,21 +8,31 @@ if (!names.length) {
   process.exit(1);
 }
 
-var checked = 0;
-names.forEach(function(name){
+var checked = [],
+    pos = 0;
+
+names.forEach(function(name, i){
   request('https://registry.npmjs.org/' + name, function(err, res) {
-    checked++;
-    if (res.statusCode === 200) {
-      console.log(name + ' is unavailable: https://www.npmjs.org/package/' + name);
-    } else if (res.statusCode === 404) {
-      console.log(name + ' is available!');
-    } else {
-      console.log('something went wrong checking', name);
-      if (err) console.error(err);
-    }
-    if (checked === names.length) process.exit(0);
+    checked[i] = res || {};
+    checked[i].name = name;
+    report();
   });
 });
+
+function report () {
+  var current;
+  for (; checked[pos]; pos++) {
+    current = checked[pos];
+    if (current.statusCode === 200) {
+      console.log(current.name + ' is unavailable: https://www.npmjs.org/package/' + current.name);
+    } else if (current.statusCode === 404) {
+      console.log(current.name + ' is available!');
+    } else {
+      console.log('something went wrong checking', current.name);
+    }
+    if (pos === names.length - 1) process.exit(0);
+  }
+}
 
 var TIME = 3000;
 setTimeout(function(){

--- a/index.js
+++ b/index.js
@@ -1,21 +1,31 @@
 var request = require('request');
 
 // Process args
-var name = process.argv.slice(2)[0];
+var names = process.argv.slice(2);
 
-if (name == null) {
-  console.log('what name should I search for?');
+if (!names.length) {
+  console.log('what name(s) should I search for?');
   process.exit(1);
 }
 
-request('https://registry.npmjs.org/' + name, function(err, res) {
-  if (res.statusCode === 200) {
-    console.log(name + ' is unavailable: https://www.npmjs.org/package/' + name);
-  } else if (res.statusCode === 404) {
-    console.log(name + ' is available!');
-  } else {
-    console.log('something went wrong!');
-    process.exit(1)
-  }
-  process.exit(0)
+var checked = 0;
+names.forEach(function(name){
+  request('https://registry.npmjs.org/' + name, function(err, res) {
+    checked++;
+    if (res.statusCode === 200) {
+      console.log(name + ' is unavailable: https://www.npmjs.org/package/' + name);
+    } else if (res.statusCode === 404) {
+      console.log(name + ' is available!');
+    } else {
+      console.log('something went wrong checking', name);
+      if (err) console.error(err);
+    }
+    if (checked === names.length) process.exit(0);
+  });
 });
+
+var TIME = 3000;
+setTimeout(function(){
+  console.error('Timed out after', TIME / 1000, 'seconds' );
+  process.exit(1);
+}, TIME);

--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ if (name == null) {
   process.exit(1);
 }
 
-request('https://www.npmjs.org/package/' + name, function(err, res) {
+request('https://registry.npmjs.org/' + name, function(err, res) {
   if (res.statusCode === 200) {
     console.log(name + ' is unavailable: https://www.npmjs.org/package/' + name);
   } else if (res.statusCode === 404) {


### PR DESCRIPTION
1. Instead of requesting a whole package webpage, just request the registry entry — significantly leaner.
2. Allow multiple name arguments.
3. Make all requests in parallel, but report in series as soon as possible (not just when all are finished).
