### PR TITLE
Faster requests and better timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,7 @@
 # namecheck
-Namecheck npm like a pro.
+Namecheck npm like a pro. Accepts multiple arguments. Sends `HEAD` queries to the npm registry API to check for package existence.
+
+```sh
+npm install -g namecheck # installation
+namecheck node git requisite # check multiple names at once
+```

--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ var checked = [],
     pos = 0;
 
 names.forEach(function(name, i){
-  request('https://registry.npmjs.org/' + name, function(err, res) {
+  request.head('https://registry.npmjs.org/' + name, function(err, res) {
     checked[i] = res || {};
     checked[i].name = name;
     report();

--- a/index.js
+++ b/index.js
@@ -16,6 +16,7 @@ names.forEach(function(name, i){
   request.head('https://registry.npmjs.org/' + name, function(err, res) {
     checked[i] = res || {};
     checked[i].name = name;
+    checked[i].err = err;
     report();
   });
 });
@@ -25,11 +26,16 @@ function report () {
   for (; checked[pos]; pos++) {
     current = checked[pos];
     if (current.statusCode === 200) {
-      console.log(current.name + ' is unavailable: https://www.npmjs.org/package/' + current.name);
+      console.log(current.name, 'is unavailable: https://www.npmjs.org/package/' + current.name);
     } else if (current.statusCode === 404) {
-      console.log(chalk.green(current.name) + ' is available!');
+      console.log(chalk.green(current.name), 'is available!');
+    } else if (current.err) {
+      console.error(chalk.red('error checking'), current.name);
+      console.error(chalk.gray(current.err));
+    } else if (current.timeout) {
+      console.error(chalk.yellow(current.name, 'timed out'));
     } else {
-      console.log(chalk.red('something went wrong checking'), current.name);
+      console.error(chalk.blue(current.name, 'had status code', current.statusCode));
     }
     if (pos === names.length - 1) process.exit(0);
   }
@@ -37,6 +43,10 @@ function report () {
 
 var TIME = 3000;
 setTimeout(function(){
-  console.error(chalk.yellow('Timed out after', TIME / 1000, 'seconds'));
+  console.error(chalk.yellow('\nTimed out after', TIME / 1000, 'seconds\n'));
+  for (var i = pos; i < names.length; i++) {
+    if (!checked[i]) checked[i] = { timeout: true, name: names[i] };
+  }
+  report();
   process.exit(1);
 }, TIME);


### PR DESCRIPTION
1. The npm registry is a couchDB API. Therefore we can use the HTTP `HEAD` request method to not even bother requesting a body — just status codes for resources that exist (200) or not (404). This makes for even faster/smaller requests, letting you check a silly number of names at a time.
2. If you do time out, it now prints all queued reports which did manage to finish (and notes which specific requests timed out).
